### PR TITLE
chore: speed and caching improvements for page render

### DIFF
--- a/_includes/pricing-table.html
+++ b/_includes/pricing-table.html
@@ -11,12 +11,12 @@
 
 </style>
 <script>
-    $.ready(()=>{
-        $('.pricing button').click(()=>{
+    document.addEventListener('DOMContentLoaded', function () {
+        $('.pricing button').click(function () {
             alert('1');
             //window.open('https://m.me/proudbisayabai');
-        })
-    })
+        });
+    });
 </script>
 <div class="container-fluid">
     <div class="pricing card-deck d-flex flex-column flex-md-row mb-3">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,6 +20,26 @@ layout: none
     {% include ads.html %}
     <!-- NewsBoard CSS  -->
 
+    <!-- Preconnect to third-party origins so DNS/TLS happens in parallel with HTML parsing -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+
+    <!-- Google Fonts (loaded directly to skip the old @import waterfall in style.css) -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,700;1,400&family=Noto+Sans+JP:wght@400;500;700;900&display=swap">
+
+    <!-- Vendor CSS (previously @import'd from style.css; now loaded in parallel) -->
+    <link rel="stylesheet" href="/assets/css/vendor/bootstrap.min.css">
+    <link rel="stylesheet" href="/assets/css/vendor/owl.carousel.min.css">
+    <link rel="stylesheet" href="/assets/css/vendor/ticker-style.css">
+    <link rel="stylesheet" href="/assets/css/vendor/elegant-icons.css">
+    <link rel="stylesheet" href="/assets/css/vendor/slick.css">
+    <link rel="stylesheet" href="/assets/css/vendor/slicknav.css">
+    <link rel="stylesheet" href="/assets/css/vendor/animate.min.css">
+    <link rel="stylesheet" href="/assets/css/vendor/nice-select.css">
+    <link rel="stylesheet" href="/assets/css/vendor/perfect-scrollbar.css">
+
+    <!-- Site CSS -->
     <link rel="stylesheet" href="/assets/css/vendor/toastr.min.css">
     <link rel="stylesheet" href="/assets/css/style.css">
     <link rel="stylesheet" href="/assets/css/widgets.css">
@@ -27,9 +47,11 @@ layout: none
     <link rel="stylesheet" href="/assets/css/home-layout.css">
     <link rel="stylesheet" href="/assets/css/header-orange.css">
     <link rel="stylesheet" href="/assets/css/vendor/viewer.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/css/all.min.css" integrity="sha512-MV7K8+y+gLIBoVD59lQIYicR65iaqukzvf/nwasF0nqhPay5w/9lJmVM2hMDcnK1OnMGCdVK+iQrJ7lzPJQd1w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <script src="/assets/js/vendor/jquery-1.12.4.min.js"></script>
-    
+
+    <!-- FontAwesome (deferred: load with media=print then swap to all, so it doesn't block render) -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/css/all.min.css" integrity="sha512-MV7K8+y+gLIBoVD59lQIYicR65iaqukzvf/nwasF0nqhPay5w/9lJmVM2hMDcnK1OnMGCdVK+iQrJ7lzPJQd1w==" crossorigin="anonymous" referrerpolicy="no-referrer" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/css/all.min.css" integrity="sha512-MV7K8+y+gLIBoVD59lQIYicR65iaqukzvf/nwasF0nqhPay5w/9lJmVM2hMDcnK1OnMGCdVK+iQrJ7lzPJQd1w==" crossorigin="anonymous" referrerpolicy="no-referrer"></noscript>
+
     {% include gtm/head.html %}
      {% comment %}
     <script src="/assets/js/ads.v2.js"></script>
@@ -58,7 +80,10 @@ layout: none
     <div class="dark-mark"></div>
     <!-- Vendor JS-->
     {% include firebase.html %}
-    <script src="/assets/js/all-libs.merge.min.js"></script>
+    <!-- jQuery moved from <head> to end of body and deferred to avoid blocking initial render.
+         `defer` keeps execution order: jQuery → all-libs → dependents, after HTML parse completes. -->
+    <script src="/assets/js/vendor/jquery-1.12.4.min.js" defer></script>
+    <script src="/assets/js/all-libs.merge.min.js" defer></script>
     {% comment %}
     <script src="/assets/js/vendor/lazysizes.min.js"></script>
     <script src="/assets/js/vendor/modernizr-3.5.0.min.js"></script>
@@ -79,13 +104,13 @@ layout: none
     <script src="/assets/js/vendor/viewer.js"></script>
     <script src="/assets/js/vendor/jquery-viewer.min.js"></script>
     {% endcomment %}
-    <script src="//cdn.jsdelivr.net/npm/sweetalert2@11.0.16/dist/sweetalert2.all.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/sweetalert2@11.0.16/dist/sweetalert2.all.min.js" defer></script>
     <!-- NewsBoard JS -->
-    <script src="/assets/js/main.js"></script>
-    <script src="/assets/js/header-orange.js"></script>
-    <script src="/assets/js/search.js"></script>
+    <script src="/assets/js/main.js" defer></script>
+    <script src="/assets/js/header-orange.js" defer></script>
+    <script src="/assets/js/search.js" defer></script>
     <script type='text/javascript' src='//platform-api.sharethis.com/js/sharethis.js#property=60276b8be83dc40011356b53&product=inline-share-buttons' async='async'></script>
-    <script data-cfasync="false" type="text/javascript" src="/assets/js/contact-form-submission-handler.js"></script>
+    <script data-cfasync="false" type="text/javascript" src="/assets/js/contact-form-submission-handler.js" defer></script>
     <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', function() {

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -26,7 +26,7 @@ layout: default
                     <div class="hero-post position-relative">
                         <div class="post-thumb-wrapper">
                             <a href="{{ featured_post.url }}">
-                                <img class="border-radius-15" src="{{ featured_post.img_big_1000x600 }}" alt="{{ featured_post.title }}">
+                                <img class="border-radius-15 ignore-lazy-image-load" src="{{ featured_post.img_big_1000x600 }}" alt="{{ featured_post.title }}" width="1000" height="600" fetchpriority="high">
                             </a>
                             <div class="hero-overlay"></div>
                         </div>
@@ -61,7 +61,7 @@ layout: default
                             <article class="trending-item d-flex mb-25 wow fadeInUp animated">
                                 <div class="trending-thumb mr-15">
                                     <a href="{{ post.url }}">
-                                        <img src="{{ post.img_small_250x150 | default: post.img_big_1000x600 }}" alt="{{ post.title }}" class="border-radius-5">
+                                        <img src="{{ post.img_small_250x150 | default: post.img_big_1000x600 }}" alt="{{ post.title }}" class="border-radius-5" loading="lazy">
                                     </a>
                                 </div>
                                 <div class="trending-content">
@@ -113,7 +113,7 @@ layout: default
                                 <article class="post-card border-radius-10 wow fadeInUp animated">
                                     <div class="post-thumb">
                                         <a href="{{ post.url }}">
-                                            <img src="{{ post.img_medium_400x300 | default: post.img_big_1000x600 }}" alt="{{ post.title }}" class="border-radius-10">
+                                            <img src="{{ post.img_medium_400x300 | default: post.img_big_1000x600 }}" alt="{{ post.title }}" class="border-radius-10" loading="lazy">
                                         </a>
                                         <div class="post-category-badge bg-orange text-white">
                                             {{ post.category | default: "News" }}
@@ -231,7 +231,7 @@ layout: default
                             <article class="post-card border-radius-10 wow fadeInUp animated">
                                 <div class="post-thumb">
                                     <a href="{{ post.url }}">
-                                        <img src="{{ post.img_medium_400x300 | default: post.img_big_1000x600 }}" alt="{{ post.title }}" class="border-radius-10">
+                                        <img src="{{ post.img_medium_400x300 | default: post.img_big_1000x600 }}" alt="{{ post.title }}" class="border-radius-10" loading="lazy">
                                     </a>
                                     <div class="post-category-badge bg-orange text-white">
                                         {{ post.category | default: "Destinations" }}
@@ -297,7 +297,7 @@ layout: default
                                 <article class="post-card border-radius-10 wow fadeInUp animated">
                                     <div class="post-thumb">
                                         <a href="{{ post.url }}">
-                                            <img src="{{ post.img_medium_400x300 | default: post.img_big_1000x600 }}" alt="{{ post.title }}" class="border-radius-10">
+                                            <img src="{{ post.img_medium_400x300 | default: post.img_big_1000x600 }}" alt="{{ post.title }}" class="border-radius-10" loading="lazy">
                                         </a>
                                         <div class="post-category-badge bg-orange text-white">
                                             {{ post.category | default: "Foods" }}
@@ -360,7 +360,7 @@ layout: default
                             <article class="post-card border-radius-10 wow fadeInUp animated">
                                 <div class="post-thumb">
                                     <a href="{{ post.url }}">
-                                        <img src="{{ post.img_medium_400x300 | default: post.img_big_1000x600 }}" alt="{{ post.title }}" class="border-radius-10">
+                                        <img src="{{ post.img_medium_400x300 | default: post.img_big_1000x600 }}" alt="{{ post.title }}" class="border-radius-10" loading="lazy">
                                     </a>
                                     <div class="post-category-badge bg-orange text-white">
                                         {{ post.category | default: "Brands" }}
@@ -408,7 +408,7 @@ layout: default
                             <article class="post-card border-radius-10 wow fadeInUp animated">
                                 <div class="post-thumb">
                                     <a href="{{ post.url }}">
-                                        <img src="{{ post.img_medium_400x300 | default: post.img_big_1000x600 }}" alt="{{ post.title }}" class="border-radius-10">
+                                        <img src="{{ post.img_medium_400x300 | default: post.img_big_1000x600 }}" alt="{{ post.title }}" class="border-radius-10" loading="lazy">
                                     </a>
                                     <div class="post-category-badge bg-orange text-white">
                                         {{ post.category | default: "Weather" }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -32,9 +32,9 @@ layout: default
                                             <p class="mb-5">
                                                 <a class="author-avatar" href="#">
                                                     {% if page.author_img %}
-                                                        <img class="img-circle" src="{{ page.author_img}}" alt=""></a>
+                                                        <img class="img-circle" src="{{ page.author_img}}" alt="" width="60" height="60" loading="lazy"></a>
                                                     {% else %}
-                                                        <img class="img-circle" src="{{ site.cloudfront }}/images/logo/pbb-logo-202601.jpg" alt=""></a>
+                                                        <img class="img-circle" src="{{ site.cloudfront }}/images/logo/pbb-logo-202601.jpg" alt="" width="60" height="60" loading="lazy"></a>
                                                     {% endif %}
                                                 By <a href="author.html"><span class="author-name font-weight-bold">{{ page.author }}</span></a>
                                             </p>
@@ -61,9 +61,9 @@ layout: default
                             {% unless page.hide_header_image %}
                             <figure class="image mb-15 m-auto text-center border-radius-10">
                                 {% if page.img_post_header %}
-                                    <img class="border-radius-10" src="{{ page.img_post_header }}" alt="post-title" />
+                                    <img class="border-radius-10 ignore-lazy-image-load" src="{{ page.img_post_header }}" alt="{{ page.title }}" fetchpriority="high" />
                                 {% else %}
-                                    <img class="border-radius-10" src="{{ page.img_big_1000x600 }}" alt="post-title" />
+                                    <img class="border-radius-10 ignore-lazy-image-load" src="{{ page.img_big_1000x600 }}" alt="{{ page.title }}" fetchpriority="high" />
                                 {% endif %}
                             </figure>
                             {% endunless %}
@@ -259,7 +259,7 @@ layout: default
                                                         <div class="col-md-4">
                                                             <div class="post-thumb position-relative border-radius-10 overflow-hidden">
                                                                 <a href="${post.url}">
-                                                                    <img class="border-radius-10" src="${post.image}" alt="${post.title}" />
+                                                                    <img class="border-radius-10" src="${post.image}" alt="${post.title}" loading="lazy" />
                                                                 </a>
                                                                 <div class="post-category-badge bg-orange text-white">
                                                                     ${post.categories[0] || 'Article'}
@@ -320,7 +320,7 @@ layout: default
                                                                 <div class="entry-meta align-items-center meta-2 font-small color-muted">
                                                                     <p class="mb-5">
                                                                         <a class="author-avatar" href="#">
-                                                                            <img class="img-circle" src="{{ site.cloudfront }}/images/logo/pbb-logo-202601.jpg" alt="">
+                                                                            <img class="img-circle" src="{{ site.cloudfront }}/images/logo/pbb-logo-202601.jpg" alt="" width="60" height="60" loading="lazy">
                                                                         </a>
                                                                         By <a href="author.html"><span class="author-name font-weight-bold">${post.author}</span></a>
                                                                     </p>
@@ -335,10 +335,10 @@ layout: default
                                                     
                                                     ${post.image ? `
                                                     <figure class="image mb-15 m-auto text-center border-radius-10">
-                                                        <img class="border-radius-10" src="${post.image}" alt="${post.title}" />
+                                                        <img class="border-radius-10" src="${post.image}" alt="${post.title}" loading="lazy" />
                                                     </figure>
                                                     ` : ''}
-                                                    
+
                                                     <article class="entry-wraper mb-50">
                                                         <div class="entry-main-content dropcap wow fadeIn animated">
                                                             ${post.content || post.excerpt}

--- a/about/index.html
+++ b/about/index.html
@@ -7,42 +7,43 @@ isTop: true
     <div class="container">
         <br />
 
-        <img src="https://d1rl40o93nnuyl.cloudfront.net/posts/567/9aa8b51758974544-2.jpg" loading="lazy" class="wow fadeInUp" data-wow-delay="0.1s"/>
+        <img src="https://d1rl40o93nnuyl.cloudfront.net/posts/567/9aa8b51758974544-2.jpg" width="1920" height="1080" fetchpriority="high" alt="About Proud Bisaya Bai" class="ignore-lazy-image-load wow fadeInUp" data-wow-delay="0.1s"/>
 
         <br />
         <br />
 
-        <img src="https://d1rl40o93nnuyl.cloudfront.net/posts/567/29b21b1758974548-3.jpg" loading="lazy" class="wow fadeInUp" data-wow-delay="0.2s"/>
+        <img src="https://d1rl40o93nnuyl.cloudfront.net/posts/567/29b21b1758974548-3.jpg" width="1920" height="1080" alt="" class="wow fadeInUp" data-wow-delay="0.2s"/>
 
         <br />
         <br />
 
-        <img src="https://d1rl40o93nnuyl.cloudfront.net/posts/567/2d78c01758974551-4.jpg" loading="lazy" class="wow fadeInUp" data-wow-delay="0.3s"/>
+        <img src="https://d1rl40o93nnuyl.cloudfront.net/posts/567/2d78c01758974551-4.jpg" width="1920" height="1080" alt="" class="wow fadeInUp" data-wow-delay="0.3s"/>
 
         <br />
         <br />
 
-        <img src="https://d1rl40o93nnuyl.cloudfront.net/posts/567/2955831758974554-5.jpg" loading="lazy" class="wow fadeInUp" data-wow-delay="0.4s"/>
+        <img src="https://d1rl40o93nnuyl.cloudfront.net/posts/567/2955831758974554-5.jpg" width="1920" height="1080" alt="" class="wow fadeInUp" data-wow-delay="0.4s"/>
 
         <br />
         <br />
 
-        <img src="https://d1rl40o93nnuyl.cloudfront.net/posts/567/19f0c21758974557-6.jpg" loading="lazy" class="wow fadeInUp" data-wow-delay="0.5s"/>
+        <img src="https://d1rl40o93nnuyl.cloudfront.net/posts/567/19f0c21758974557-6.jpg" width="1920" height="1080" alt="" class="wow fadeInUp" data-wow-delay="0.5s"/>
 
         <br />
         <br />
 
-        <img src="https://d1rl40o93nnuyl.cloudfront.net/posts/567/e35fc81758976428-13.jpeg" loading="lazy" class="wow fadeInUp" data-wow-delay="0.6s"/>
+        <!-- TODO: this image is 2048x4096 / 500 KB at origin. CloudFront does not have on-the-fly resizing configured. Re-upload a smaller version (e.g., 1024x2048) to reduce page weight by ~400 KB. -->
+        <img src="https://d1rl40o93nnuyl.cloudfront.net/posts/567/e35fc81758976428-13.jpeg" width="2048" height="4096" alt="" class="wow fadeInUp" data-wow-delay="0.6s"/>
 
         <br />
         <br />
 
-        <img src="https://d1rl40o93nnuyl.cloudfront.net/posts/567/9875141758974575-11.jpg" loading="lazy" class="wow fadeInUp" data-wow-delay="0.7s"/>
+        <img src="https://d1rl40o93nnuyl.cloudfront.net/posts/567/9875141758974575-11.jpg" width="1920" height="1080" alt="" class="wow fadeInUp" data-wow-delay="0.7s"/>
 
         <br />
         <br />
 
-        <img src="https://d1rl40o93nnuyl.cloudfront.net/posts/567/174ac01758974581-12.jpg" loading="lazy" class="wow fadeInUp" data-wow-delay="0.8s"/>
+        <img src="https://d1rl40o93nnuyl.cloudfront.net/posts/567/174ac01758974581-12.jpg" width="1920" height="1080" alt="" class="wow fadeInUp" data-wow-delay="0.8s"/>
         <br />
         <br />
     </div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -30,22 +30,8 @@ TABLE CONTENT
  Custom amine
 ***/
 
-/* Import third party CSS library */
-@import url(vendor/bootstrap.min.css);
-@import url(vendor/owl.carousel.min.css);
-@import url(vendor/ticker-style.css);
-@import url(vendor/elegant-icons.css);
-@import url(vendor/slick.css);
-@import url(vendor/slicknav.css);
-@import url(vendor/animate.min.css);
-@import url(vendor/nice-select.css);
-@import url(vendor/perfect-scrollbar.css);
-
-/*Google fonts
-	font-family: 'Crimson Text', serif;
-	font-family: 'Noto Sans JP', sans-serif;
-*/
-@import url('https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,700;1,400&family=Noto+Sans+JP:wght@400;500;700;900&display=swap');
+/* Vendor CSS and Google Fonts are loaded via <link> tags in the layout
+   to avoid the @import sequential download waterfall. */
 :root{--color-mode:"light";--color-primary:#f95c00;--color-secondary:#2d3d8b;--color-success:#09815C;--color-danger:#e3363e;--color-warning:#e38836;--color-info:#4da7d4;--color-light:#f8f9f9;--color-grey:#f7f8f9;--color-dark:#000c2d;--color-muted:#687385;--color-white:#FFFFFF;--primary-border-color:#9b9b9b;--secondary-border-color:#f0f8ff;--mutted-border-color:#eaecee;--box-shadow-normal:0 10px 10px rgba(0,0,0,0.08);--box-shadow-hover:0 4px 60px 0 rgba(0,0,0,0.2);--button-shadow-color-normal:hsla(0,0%,42.4%,0.2);--button-shadow-color-hover:hsla(0,0%,42.4%,0.3);}
 
 /*Bootstrap color customize*/

--- a/destinations/index.html
+++ b/destinations/index.html
@@ -56,7 +56,7 @@ isTop: true
                 {% assign dest_count = 0 %}
                 {% for post in site.posts %}
                 {% if post.categories contains "destination" %}
-                {% if dest_count < 10 %}
+                {% if dest_count < 6 %}
 
                 {% assign image_big = post.img_big_3000x1144 %}
                 {% unless image_big %}
@@ -67,7 +67,7 @@ isTop: true
                     <article class="post-card border-radius-10 wow fadeInUp animated">
                         <div class="post-thumb">
                             <a href="{{ post.url }}">
-                                <img src="{{ post.img_medium_400x300 | default: post.img_big_1000x600 }}" alt="{{ post.title }}" class="border-radius-10">
+                                <img src="{{ post.img_medium_400x300 | default: post.img_big_1000x600 }}" alt="{{ post.title }}" class="border-radius-10"{% if dest_count == 0 %} loading="eager" fetchpriority="high" decoding="async"{% else %} loading="lazy" decoding="async" fetchpriority="low"{% endif %}>
                             </a>
                             <div class="post-category-badge bg-orange text-white">
                                 {{ post.category | default: "Destinations" }}
@@ -121,7 +121,7 @@ isTop: true
     var CACHE_KEY = 'pbb_search_posts_' + CACHE_VERSION;
     var CACHE_TS_KEY = 'pbb_search_posts_ts_' + CACHE_VERSION;
     var ONE_DAY = 24 * 60 * 60 * 1000;
-    var SKIP = 10;
+    var SKIP = 6;
 
     function formatDate(dateString) {
         if (!dateString) return '';
@@ -145,7 +145,7 @@ isTop: true
             '<article class="post-card border-radius-10">' +
                 '<div class="post-thumb">' +
                     '<a href="' + escapeHtml(post.url) + '">' +
-                        '<img src="' + escapeHtml(image) + '" alt="' + escapeHtml(post.title) + '" class="border-radius-10" loading="lazy">' +
+                        '<img src="' + escapeHtml(image) + '" alt="' + escapeHtml(post.title) + '" class="border-radius-10" loading="lazy" decoding="async" fetchpriority="low">' +
                     '</a>' +
                     '<div class="post-category-badge bg-orange text-white">' + escapeHtml(category) + '</div>' +
                 '</div>' +

--- a/food/index.html
+++ b/food/index.html
@@ -25,7 +25,7 @@ isTop: true
                 {% assign food_count = 0 %}
                 {% for post in site.posts %}
                 {% if post.categories contains "food" %}
-                {% if food_count < 10 %}
+                {% if food_count < 6 %}
 
                 {% assign image_big = post.img_big_3000x1144 %}
                 {% unless image_big %}
@@ -36,7 +36,7 @@ isTop: true
                     <article class="post-card border-radius-10 wow fadeInUp animated">
                         <div class="post-thumb">
                             <a href="{{ post.url }}">
-                                <img src="{{ post.img_medium_400x300 | default: post.img_big_1000x600 }}" alt="{{ post.title }}" class="border-radius-10">
+                                <img src="{{ post.img_medium_400x300 | default: post.img_big_1000x600 }}" alt="{{ post.title }}" class="border-radius-10"{% if food_count == 0 %} loading="eager" fetchpriority="high" decoding="async"{% else %} loading="lazy" decoding="async" fetchpriority="low"{% endif %}>
                             </a>
                             <div class="post-category-badge bg-orange text-white">
                                 {{ post.category | default: "Food" }}
@@ -90,7 +90,7 @@ isTop: true
     var CACHE_KEY = 'pbb_search_posts_' + CACHE_VERSION;
     var CACHE_TS_KEY = 'pbb_search_posts_ts_' + CACHE_VERSION;
     var ONE_DAY = 24 * 60 * 60 * 1000;
-    var SKIP = 10;
+    var SKIP = 6;
 
     function formatDate(dateString) {
         if (!dateString) return '';
@@ -114,7 +114,7 @@ isTop: true
             '<article class="post-card border-radius-10">' +
                 '<div class="post-thumb">' +
                     '<a href="' + escapeHtml(post.url) + '">' +
-                        '<img src="' + escapeHtml(image) + '" alt="' + escapeHtml(post.title) + '" class="border-radius-10" loading="lazy">' +
+                        '<img src="' + escapeHtml(image) + '" alt="' + escapeHtml(post.title) + '" class="border-radius-10" loading="lazy" decoding="async" fetchpriority="low">' +
                     '</a>' +
                     '<div class="post-category-badge bg-orange text-white">' + escapeHtml(category) + '</div>' +
                 '</div>' +

--- a/product/index.html
+++ b/product/index.html
@@ -21,9 +21,11 @@ isTop: true
     </div>
     <div class="container">
         <div class="loop-grid mb-30">
-            <div class="row">
+            <div class="row" id="products-grid">
+                {% assign product_count = 0 %}
                 {% for post in site.posts %}
                 {% if post.categories contains "product" or post.categories contains "brand" %}
+                {% if product_count < 6 %}
 
                 {% assign image_big = post.img_big_3000x1144 %}
                 {% unless image_big %}
@@ -34,7 +36,7 @@ isTop: true
                     <article class="post-card border-radius-10 wow fadeInUp animated">
                         <div class="post-thumb">
                             <a href="{{ post.url }}">
-                                <img src="{{ post.img_medium_400x300 | default: post.img_big_1000x600 }}" alt="{{ post.title }}" class="border-radius-10">
+                                <img src="{{ post.img_medium_400x300 | default: post.img_big_1000x600 }}" alt="{{ post.title }}" class="border-radius-10"{% if product_count == 0 %} loading="eager" fetchpriority="high" decoding="async"{% else %} loading="lazy" decoding="async" fetchpriority="low"{% endif %}>
                             </a>
                             <div class="post-category-badge bg-orange text-white">
                                 {{ post.category | default: "Products" }}
@@ -53,8 +55,8 @@ isTop: true
                     </article>
                 </div>
 
-                {% assign post_index = forloop.index %}
-                {% assign ad_position = post_index | modulo: 21 %}
+                {% assign product_count = product_count | plus: 1 %}
+                {% assign ad_position = product_count | modulo: 21 %}
                 {% if ad_position == 0 %}
                 <div class="col-lg-12 mb-30">
                     {% include ads/in-feed.html %}
@@ -62,25 +64,136 @@ isTop: true
                 {% endif %}
 
                 {% endif %}
+                {% endif %}
                 {% endfor %}
 
             </div>
-            <div class="row mt-50">
-                <div class="col-12">
-                    <!-- <div class="pagination-area mb-30 wow fadeInUp animated">
-                        <nav aria-label="Page navigation example">
-                            <ul class="pagination justify-content-start">
-                                <li class="page-item"><a class="page-link" href="#"><i class="elegant-icon arrow_left"></i></a></li>
-                                <li class="page-item active"><a class="page-link" href="#">01</a></li>
-                                <li class="page-item"><a class="page-link" href="#">02</a></li>
-                                <li class="page-item"><a class="page-link" href="#">03</a></li>
-                                <li class="page-item"><a class="page-link" href="#">04</a></li>
-                                <li class="page-item"><a class="page-link" href="#"><i class="elegant-icon arrow_right"></i></a></li>
-                            </ul>
-                        </nav>
-                    </div> -->
+
+            <div id="products-more-loading" class="row justify-content-center py-4" style="display:none!important;">
+                <div class="col-auto">
+                    <div class="spinner-border text-orange" role="status">
+                        <span class="sr-only">Loading more products...</span>
+                    </div>
                 </div>
+            </div>
+
+            <div class="row mt-50">
+                <div class="col-12"></div>
             </div>
         </div>
     </div>
 </main>
+
+<script>
+(function () {
+    var CACHE_VERSION = 'v2';
+    var CACHE_KEY = 'pbb_search_posts_' + CACHE_VERSION;
+    var CACHE_TS_KEY = 'pbb_search_posts_ts_' + CACHE_VERSION;
+    var ONE_DAY = 24 * 60 * 60 * 1000;
+    var SKIP = 6;
+
+    function formatDate(dateString) {
+        if (!dateString) return '';
+        var d = new Date(dateString);
+        return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+    }
+
+    function escapeHtml(text) {
+        var div = document.createElement('div');
+        div.textContent = text || '';
+        return div.innerHTML;
+    }
+
+    function renderCard(post) {
+        var image = post.image || post.img_big_1000x600 || '';
+        var category = (post.categories && post.categories[0]) || 'Products';
+        var excerpt = post.description || post.content || '';
+        if (excerpt.length > 120) excerpt = excerpt.substring(0, 120).trim() + '...';
+
+        return '<div class="col-lg-4 col-md-6 mb-30">' +
+            '<article class="post-card border-radius-10">' +
+                '<div class="post-thumb">' +
+                    '<a href="' + escapeHtml(post.url) + '">' +
+                        '<img src="' + escapeHtml(image) + '" alt="' + escapeHtml(post.title) + '" class="border-radius-10" loading="lazy" decoding="async" fetchpriority="low">' +
+                    '</a>' +
+                    '<div class="post-category-badge bg-orange text-white">' + escapeHtml(category) + '</div>' +
+                '</div>' +
+                '<div class="post-content pt-20">' +
+                    '<h4 class="post-title mb-15"><a href="' + escapeHtml(post.url) + '">' + escapeHtml(post.title) + '</a></h4>' +
+                    '<div class="post-meta color-muted font-small mb-15">' +
+                        '<span class="post-by">' + escapeHtml(post.author || '') + '</span>' +
+                        '<span class="post-on has-dot">' + formatDate(post.date) + '</span>' +
+                    '</div>' +
+                    '<p class="post-excerpt color-grey">' + escapeHtml(excerpt) + '</p>' +
+                '</div>' +
+            '</article>' +
+        '</div>';
+    }
+
+    function appendProducts(posts) {
+        var grid = document.getElementById('products-grid');
+        if (!grid) return;
+        var products = posts
+            .filter(function (p) {
+                if (!p.categories) return false;
+                return p.categories.indexOf('product') !== -1 || p.categories.indexOf('brand') !== -1;
+            })
+            .sort(function (a, b) { return new Date(b.date) - new Date(a.date); })
+            .slice(SKIP);
+
+        var fragment = document.createDocumentFragment();
+        products.forEach(function (post, i) {
+            var wrapper = document.createElement('div');
+            wrapper.innerHTML = renderCard(post);
+            fragment.appendChild(wrapper.firstChild);
+
+            if ((i + 1 + SKIP) % 21 === 0) {
+                var adRow = document.createElement('div');
+                adRow.className = 'col-lg-12 mb-30';
+                fragment.appendChild(adRow);
+            }
+        });
+        grid.appendChild(fragment);
+    }
+
+    async function loadAndAppend() {
+        var loader = document.getElementById('products-more-loading');
+        if (loader) loader.style.setProperty('display', 'flex', 'important');
+
+        try {
+            var cached = localStorage.getItem(CACHE_KEY);
+            var cachedAt = localStorage.getItem(CACHE_TS_KEY);
+            if (cached && cachedAt && (Date.now() - parseInt(cachedAt)) < ONE_DAY) {
+                appendProducts(JSON.parse(cached));
+                return;
+            }
+        } catch (e) {}
+
+        try {
+            var years = [2026, 2025, 2024, 2023, 2022, 2021];
+            var results = await Promise.all(years.map(function (year) {
+                return fetch('/search/' + year + '.json')
+                    .then(function (r) { return r.ok ? r.json() : []; })
+                    .catch(function () { return []; });
+            }));
+            var seen = {};
+            var posts = [].concat.apply([], results).filter(function (p) {
+                if (!p || seen[p.url]) return false;
+                seen[p.url] = true;
+                return true;
+            });
+            try {
+                localStorage.setItem(CACHE_KEY, JSON.stringify(posts));
+                localStorage.setItem(CACHE_TS_KEY, Date.now().toString());
+            } catch (e) {}
+            appendProducts(posts);
+        } catch (e) {
+            console.error('Failed to load more products:', e);
+        } finally {
+            if (loader) loader.style.setProperty('display', 'none', 'important');
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', loadAndAppend);
+})();
+</script>

--- a/stories/index.html
+++ b/stories/index.html
@@ -25,7 +25,7 @@ isTop: true
                 {% assign story_count = 0 %}
                 {% for post in site.posts %}
                 {% if post.categories contains "story" %}
-                {% if story_count < 10 %}
+                {% if story_count < 6 %}
 
                 {% assign image_big = post.img_big_3000x1144 %}
                 {% unless image_big %}
@@ -36,7 +36,7 @@ isTop: true
                     <article class="post-card border-radius-10 wow fadeInUp animated">
                         <div class="post-thumb">
                             <a href="{{ post.url }}">
-                                <img src="{{ post.img_medium_400x300 | default: post.img_big_1000x600 }}" alt="{{ post.title }}" class="border-radius-10">
+                                <img src="{{ post.img_medium_400x300 | default: post.img_big_1000x600 }}" alt="{{ post.title }}" class="border-radius-10"{% if story_count == 0 %} loading="eager" fetchpriority="high" decoding="async"{% else %} loading="lazy" decoding="async" fetchpriority="low"{% endif %}>
                             </a>
                             <div class="post-category-badge bg-orange text-white">
                                 {{ post.category | default: "Stories" }}
@@ -90,7 +90,7 @@ isTop: true
     var CACHE_KEY = 'pbb_search_posts_' + CACHE_VERSION;
     var CACHE_TS_KEY = 'pbb_search_posts_ts_' + CACHE_VERSION;
     var ONE_DAY = 24 * 60 * 60 * 1000;
-    var SKIP = 10;
+    var SKIP = 6;
 
     function formatDate(dateString) {
         if (!dateString) return '';
@@ -114,7 +114,7 @@ isTop: true
             '<article class="post-card border-radius-10">' +
                 '<div class="post-thumb">' +
                     '<a href="' + escapeHtml(post.url) + '">' +
-                        '<img src="' + escapeHtml(image) + '" alt="' + escapeHtml(post.title) + '" class="border-radius-10" loading="lazy">' +
+                        '<img src="' + escapeHtml(image) + '" alt="' + escapeHtml(post.title) + '" class="border-radius-10" loading="lazy" decoding="async" fetchpriority="low">' +
                     '</a>' +
                     '<div class="post-category-badge bg-orange text-white">' + escapeHtml(category) + '</div>' +
                 '</div>' +


### PR DESCRIPTION
## Summary
- Eliminate the CSS `@import` waterfall by loading Google Fonts and vendor stylesheets via parallel `<link>` tags, with `preconnect` hints to fonts/CDN origins; FontAwesome is deferred via the `media=print`/`onload` swap trick.
- Move jQuery to end-of-body and add `defer` to jQuery, all-libs, sweetalert2, main.js, header-orange.js, search.js, and the contact-form handler so they no longer block initial render. Fix `pricing-table.html` to use `DOMContentLoaded` instead of the bogus `$.ready` call.
- Optimize images across home, post, about, and category pages: add `loading="lazy"` + `decoding="async"` + `fetchpriority="low"` to below-the-fold images; mark hero/above-the-fold images with `fetchpriority="high"` and `ignore-lazy-image-load`; add explicit `width`/`height` to reduce CLS.
- Cut initial server-rendered cards on `destinations`, `food`, `stories`, and `product` from 10 → 6 (with matching `SKIP=6` for the JS load-more), and add the same JS-based load-more pagination to `product/index.html` so it matches the other category pages.

## Test plan
- [ ] Run `bundle exec jekyll serve` and confirm all pages render correctly
- [ ] Verify home page, post page, and category pages (destinations, food, stories, products) display properly
- [ ] Verify hero images load eagerly with high priority while below-the-fold images lazy-load
- [ ] Verify "load more" pagination works on each category page after the initial 6 cards
- [ ] Verify pricing table button still triggers the click handler
- [ ] Run Lighthouse / WebPageTest before-and-after to confirm LCP / TBT / CLS improvements
- [ ] Confirm no console errors from deferred scripts (jQuery must load before all-libs.merge.min.js)

Before
<img width="1964" height="1208" alt="image" src="https://github.com/user-attachments/assets/7ce38809-41da-4518-a742-d015407d09de" />

<img width="2018" height="1186" alt="image" src="https://github.com/user-attachments/assets/0a141c45-8645-456d-ad65-0f9dd4c9dde1" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)