### PR TITLE
Update Facebook follower count to 513k

### DIFF
--- a/_data/ads.json
+++ b/_data/ads.json
@@ -4,13 +4,13 @@
         "img_big_3000x1144": "https://d3hukd8e3cn3kb.cloudfront.net/images/posts/logos/new_logo.jpg",
         "img_big_1000x600": "https://d3hukd8e3cn3kb.cloudfront.net/images/posts/logos/new_logo.jpg",
         "title": "Advertise with Us",
-        "sub_title": "Reach over 500k people with your brand",
+        "sub_title": "Reach over 510k people with your brand",
         "description": "Proud Bisaya Bai helps you grow your visibility.",
         "facebook": "https://facebook.com/proudbisayabai",
         "click_url": "https://facebook.com/proudbisayabai"
     },
     "followers":{
-        "facebook": "504,000",
+        "facebook": "513,000",
         "instagram": "1,700"
     },
     "partners_sponsors": [


### PR DESCRIPTION
Facebook follower count updated from 504,000 → 513,000. Also updated `article.sub_title` from "Reach over 500k people with your brand" to "Reach over 510k people with your brand" as the count crossed the 510k tier.

Count sourced from Google's cached/indexed search snippet for facebook.com/proudbisayabai — may lag the live page by days to weeks. Please verify against the live page if precision matters.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6mtyUBaPTeaXzWT1kvoUc)_