### PR TITLE
SEO quick wins: per-page meta description, canonical, JSON-LD, absolute og:url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ address:
 
 
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://proudbisayabai.ph" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: proudbisayabai
 github_username:  linkmalloc
 url_sitemap: "https://proudbisayabai.ph"

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -13,7 +13,7 @@
     {% assign og_desc = site.description %}
 {% endif %}
 
-<meta property="og:url" content="{{ page.url }}" />
+<meta property="og:url" content="{{ site.url }}{{ page.url }}" />
 <meta property="og:type" content="article" />
 <meta property="og:title" content="{{ page.title }}" />
 <meta property="og:description" content="{{ og_desc | truncatewords: 50 }}" />

--- a/_includes/structured-data.html
+++ b/_includes/structured-data.html
@@ -1,0 +1,57 @@
+{% comment %}
+  JSON-LD structured data.
+  - NewsMediaOrganization: emitted on every page (publisher identity, logo, social profiles).
+  - NewsArticle: emitted only on posts (layout: post) for Top Stories / rich-result eligibility.
+  Values are passed through `jsonify` so titles/descriptions with quotes or colons stay valid JSON.
+{% endcomment %}
+{% assign sd_logo = site.cloudfront | append: '/images/logo/pbb-logo-202601.jpg' %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsMediaOrganization",
+  "name": {{ site.title | jsonify }},
+  "url": "{{ site.url }}",
+  "logo": {
+    "@type": "ImageObject",
+    "url": "{{ sd_logo }}"
+  },
+  "sameAs": [
+    {{ site.facebook | jsonify }},
+    {{ site.instagram | jsonify }}
+  ]
+}
+</script>
+{% if page.layout == 'post' %}
+{% assign sd_desc = page.description | strip_html | normalize_whitespace | truncate: 300 %}
+{% assign sd_image = page.img_big_1000x600 | default: page.img_big_3000x1144 | default: sd_logo %}
+{% assign sd_date = page.published_at | default: page.date | date_to_xmlschema %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "{{ site.url }}{{ page.url }}"
+  },
+  "headline": {{ page.title | truncate: 110 | jsonify }},
+  "description": {{ sd_desc | jsonify }},
+  "image": [
+    {{ sd_image | jsonify }}
+  ],
+  "datePublished": "{{ sd_date }}",
+  "dateModified": "{{ sd_date }}",
+  "author": {
+    "@type": "Person",
+    "name": {{ page.author | default: site.title | jsonify }}
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": {{ site.title | jsonify }},
+    "logo": {
+      "@type": "ImageObject",
+      "url": "{{ sd_logo }}"
+    }
+  }
+}
+</script>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,10 +13,17 @@ layout: none
         {% capture title %}{{ page.title }} | {{ site.title }} {% endcapture %}
     {% endif %}
     <title>{{ title }} </title>
-    <meta name="description" content="{{ site.description }}">
+    {% if page.description %}
+        {% assign meta_desc = page.description %}
+    {% else %}
+        {% assign meta_desc = site.description %}
+    {% endif %}
+    <meta name="description" content="{{ meta_desc | strip_html | normalize_whitespace | truncate: 300 }}">
+    <link rel="canonical" href="{{ site.url }}{{ page.url | replace: 'index.html', '' }}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" type="image/x-icon" href="https://d1rl40o93nnuyl.cloudfront.net/posts/567/6941e31772016837-17.png">
     {% include seo.html %}
+    {% include structured-data.html %}
     {% include ads.html %}
     <!-- NewsBoard CSS  -->
 


### PR DESCRIPTION
## Summary

Four high-leverage, low-risk SEO fixes that apply across **all ~2,382 pages**. Aimed at the "cebu city" long-tail and Google Top Stories eligibility.

| # | Fix | File |
|---|-----|------|
| 1 | **Per-page `<meta name="description">`** — was hardcoded to `site.description` (identical tagline on every page); now uses each page's own `description:` front matter, falling back to `site.description`. | `_layouts/default.html` |
| 2 | **Canonical tags** — absolute `<link rel="canonical">` on every page (`index.html` stripped). None existed before. | `_layouts/default.html` |
| 3 | **JSON-LD structured data** — `NewsMediaOrganization` sitewide + `NewsArticle` on posts (headline, ISO dates, author, publisher, image, mainEntityOfPage). | `_includes/structured-data.html` (new) |
| 4 | **Absolute `og:url`** (was a relative path) + **set `site.url`** so canonical/OG/schema resolve to absolute URLs. | `_includes/seo.html`, `_config.yml` |

## Validation

Ran a real `jekyll build` and inspected generated HTML:
- Post emits its own meta description instead of the site tagline.
- `canonical` and `og:url` are absolute (`https://proudbisayabai.ph/…`).
- Both JSON-LD blocks parse as **valid JSON** (`NewsMediaOrganization` on a landing page, `NewsArticle` on a post with all fields populated, dates in ISO 8601 `+08:00`).

## Follow-ups (not in this PR)
- Normalize JSON-LD `author` (strip role suffixes like "- PBB Intern").
- Confirm the `NewsArticle` logo asset meets Google's size guidance.
- Next levers: `/cebu-city/` pillar page + Google News sitemap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)