### PR TITLE
Add Winzir rotating image ads; hide Google AdSense

### DIFF
--- a/_data/winzir.yml
+++ b/_data/winzir.yml
@@ -1,0 +1,51 @@
+# Winzir custom image ads (served from CloudFront; local images/ is gitignored).
+#
+# provider: 'winzir' shows the rotating custom-image ads below and HIDES Google AdSense.
+#           set to 'google' to restore AdSense everywhere.
+provider: winzir
+
+# CloudFront base. Full url = {base_url}/{folder-type}/{filename}
+base_url: https://d1rl40o93nnuyl.cloudfront.net/ads/winzir
+
+# Rotation interval in milliseconds (30s). Single constant used by every ad slot.
+rotate_ms: 30000
+
+# Where a click on any winzir ad should go.
+click_url: "https://winzir.ph/affiliates/?btag=557078_l386511"
+
+alt: "Winzir"
+
+# Images grouped by folder type. Mirrors images/posts/winzir-ads/<type>/ and the
+# CloudFront layout /ads/winzir/<type>/<file>. Each slot rotates through its full list.
+images:
+  leaderboard:
+    - A950x250.png
+    - B950x250.png
+    - C950x250.jpg
+    - D950x250.jpg
+  rectangle:
+    - A300x250.png
+    - B300x250.png
+    - C300x250.jpg
+    - D300x250.jpg
+    - A315x300.png
+    - B315x300.png
+    - C315x300.jpg
+    - C315x300.png
+    - D315x300.jpg
+    - A400x350.png
+    - "B400x350 - taboola.png"
+    - "C400x350 - taboola.jpg"
+    - D400x350.jpg
+  inline-banner:
+    - A300x100.png
+    - B300x100.png
+    - C300x100.jpg
+    - D300x100.jpg
+    - A305x99.png
+    - B305x99.png
+    - C305x99.jpg
+    - D305x99.jpg
+    - B468x60.png
+    - C468x60.jpg
+    - D468x60.jpg

--- a/_includes/ads/home-banner.html
+++ b/_includes/ads/home-banner.html
@@ -1,3 +1,5 @@
+{% comment %} Leaderboard slot. Google hidden while site.data.winzir.provider != 'google'. {% endcomment %}
+{% if site.data.winzir.provider == 'google' %}
 <!-- Home Page Banner Ad - 1140x200 -->
 <div class="home-banner-ad" style="width:100%; min-width: 300px;">
     <!-- Google AdSense Banner Ad -->
@@ -18,3 +20,6 @@
         <p class="text-muted mb-0">Advertisement Banner - 1140x200</p>
     </div>
 </noscript>
+{% else %}
+{% include ads/winzir/leaderboard.html %}
+{% endif %}

--- a/_includes/ads/in-feed.html
+++ b/_includes/ads/in-feed.html
@@ -1,3 +1,5 @@
+{% comment %} In-feed slot. Google hidden while site.data.winzir.provider != 'google'. {% endcomment %}
+{% if site.data.winzir.provider == 'google' %}
 <div class="home-banner-ad" style="width:100%; min-width: 300px;">
      <ins class="adsbygoogle"
           style="display:block"
@@ -9,3 +11,6 @@
           (adsbygoogle = window.adsbygoogle || []).push({});
      </script>
 </div>
+{% else %}
+{% include ads/winzir/rectangle.html %}
+{% endif %}

--- a/_includes/ads/rectangle.html
+++ b/_includes/ads/rectangle.html
@@ -1,5 +1,7 @@
+{% comment %} Rectangle slot. Google hidden while site.data.winzir.provider != 'google'. {% endcomment %}
+{% if site.data.winzir.provider == 'google' %}
 <!-- Google AdSense Rectangle Ad - 300x250 -->
-<div class="home-banner-ad" style="width:100%; min-width: 300px;"></div>
+<div class="home-banner-ad" style="width:100%; min-width: 300px;">
      <ins class="adsbygoogle"
           style="display:block"
           data-ad-client="ca-pub-1359231121915800"
@@ -10,3 +12,6 @@
           (adsbygoogle = window.adsbygoogle || []).push({});
      </script>
 </div>
+{% else %}
+{% include ads/winzir/rectangle.html %}
+{% endif %}

--- a/_includes/ads/vertical.html
+++ b/_includes/ads/vertical.html
@@ -1,3 +1,5 @@
+{% comment %} Vertical/sidebar slot. Google hidden while site.data.winzir.provider != 'google'. {% endcomment %}
+{% if site.data.winzir.provider == 'google' %}
 <div style="width: 100%; min-width: 300px;">
   <ins class="adsbygoogle"
      style="display:block"
@@ -9,3 +11,6 @@
       (adsbygoogle = window.adsbygoogle || []).push({});
   </script>
 </div>
+{% else %}
+{% include ads/winzir/rectangle.html %}
+{% endif %}

--- a/_includes/ads/winzir/_carousel.html
+++ b/_includes/ads/winzir/_carousel.html
@@ -1,0 +1,24 @@
+{% comment %}
+  Winzir rotating image ad (custom-image duplicate of a Google ad slot).
+  Param: type = folder type (leaderboard | rectangle | inline-banner).
+  Rotates through every image in site.data.winzir.images[type], one every
+  site.data.winzir.rotate_ms milliseconds. Rotation handled by the shared
+  script in _layouts/default.html.
+{% endcomment %}
+{% assign w = site.data.winzir %}
+{% assign type = include.type %}
+{% assign imgs = w.images[type] %}
+{% if imgs and imgs.size > 0 %}
+<div class="winzir-rotator ignore-lazy-image-load" data-interval="{{ w.rotate_ms }}" style="width:100%; min-width:300px; text-align:center;">
+  {% for img in imgs %}
+    {% assign src = img | replace: ' ', '%20' %}
+    <a class="winzir-slide{% if forloop.first %} is-active{% endif %}"
+       href="{{ w.click_url }}"{% if w.click_url != '#' %} target="_blank" rel="noopener sponsored nofollow"{% endif %}{% unless forloop.first %} style="display:none;"{% endunless %}>
+      <img class="ignore-lazy-image-load"
+           src="{{ w.base_url }}/{{ type }}/{{ src }}"
+           alt="{{ w.alt }}" loading="lazy" decoding="async"
+           style="max-width:100%; height:auto; border-radius:10px; display:inline-block;">
+    </a>
+  {% endfor %}
+</div>
+{% endif %}

--- a/_includes/ads/winzir/inline-banner.html
+++ b/_includes/ads/winzir/inline-banner.html
@@ -1,0 +1,1 @@
+{% include ads/winzir/_carousel.html type='inline-banner' %}

--- a/_includes/ads/winzir/leaderboard.html
+++ b/_includes/ads/winzir/leaderboard.html
@@ -1,0 +1,1 @@
+{% include ads/winzir/_carousel.html type='leaderboard' %}

--- a/_includes/ads/winzir/rectangle.html
+++ b/_includes/ads/winzir/rectangle.html
@@ -1,0 +1,1 @@
+{% include ads/winzir/_carousel.html type='rectangle' %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -76,9 +76,14 @@ layout: none
     {% include footer.html %}
     <!-- End Footer -->
     {% unless site.data.winzir.provider == 'google' %}
-    <!-- Winzir rotating ads: swap each slot's image every rotate_ms (30s). -->
+    <!-- Winzir rotating ads: cross-fade each slot's image every rotate_ms (30s). -->
+    <style>
+      .winzir-slide { transition: opacity 600ms ease-in-out; will-change: opacity; }
+      .winzir-slide.is-fading { opacity: 0; }
+    </style>
     <script>
     (function () {
+      var FADE_MS = 600; // keep in sync with the CSS transition above
       function initWinzirRotators() {
         var rotators = document.querySelectorAll('.winzir-rotator');
         for (var n = 0; n < rotators.length; n++) {
@@ -90,11 +95,19 @@ layout: none
             var i = 0;
             var interval = parseInt(r.getAttribute('data-interval'), 10) || 30000;
             setInterval(function () {
-              slides[i].style.display = 'none';
-              slides[i].classList.remove('is-active');
+              var cur = slides[i];
+              var next = slides[(i + 1) % slides.length];
+              cur.classList.add('is-fading'); // fade the current image out
+              window.setTimeout(function () {
+                cur.style.display = 'none';
+                cur.classList.remove('is-fading', 'is-active');
+                next.classList.add('is-fading'); // stage next hidden, then reveal
+                next.style.display = '';
+                void next.offsetWidth;           // force reflow so the fade-in animates
+                next.classList.remove('is-fading');
+                next.classList.add('is-active');
+              }, FADE_MS);
               i = (i + 1) % slides.length;
-              slides[i].style.display = '';
-              slides[i].classList.add('is-active');
             }, interval);
           })(rotators[n]);
         }

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,7 +17,8 @@ layout: none
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" type="image/x-icon" href="https://d1rl40o93nnuyl.cloudfront.net/posts/567/6941e31772016837-17.png">
     {% include seo.html %}
-    {% include ads.html %}
+    {% comment %} Google AdSense loader — hidden while site.data.winzir.provider != 'google'. {% endcomment %}
+    {% if site.data.winzir.provider == 'google' %}{% include ads.html %}{% endif %}
     <!-- NewsBoard CSS  -->
 
     <!-- Preconnect to third-party origins so DNS/TLS happens in parallel with HTML parsing -->
@@ -74,6 +75,35 @@ layout: none
     {{ content }}
     {% include footer.html %}
     <!-- End Footer -->
+    {% unless site.data.winzir.provider == 'google' %}
+    <!-- Winzir rotating ads: swap each slot's image every rotate_ms (30s). -->
+    <script>
+    (function () {
+      function initWinzirRotators() {
+        var rotators = document.querySelectorAll('.winzir-rotator');
+        for (var n = 0; n < rotators.length; n++) {
+          (function (r) {
+            if (r.getAttribute('data-winzir-init')) return;
+            r.setAttribute('data-winzir-init', '1');
+            var slides = r.querySelectorAll('.winzir-slide');
+            if (slides.length < 2) return;
+            var i = 0;
+            var interval = parseInt(r.getAttribute('data-interval'), 10) || 30000;
+            setInterval(function () {
+              slides[i].style.display = 'none';
+              slides[i].classList.remove('is-active');
+              i = (i + 1) % slides.length;
+              slides[i].style.display = '';
+              slides[i].classList.add('is-active');
+            }, interval);
+          })(rotators[n]);
+        }
+      }
+      if (document.readyState !== 'loading') initWinzirRotators();
+      else document.addEventListener('DOMContentLoaded', initWinzirRotators);
+    })();
+    </script>
+    {% endunless %}
     <button id="scroll-to-top" aria-label="Scroll to top">
         <i class="fas fa-chevron-up"></i>
     </button>


### PR DESCRIPTION
## Summary
Replaces Google AdSense slots with direct-sold **Winzir** image ads served from CloudFront (`/ads/winzir/<type>/`). Each slot rotates through its images, one every **30s**. Google is preserved but hidden behind a single toggle.

## How it works
- **`_data/winzir.yml`** — single source of truth:
  - `provider: winzir` shows custom images and **hides AdSense**; set to `google` to restore AdSense everywhere.
  - `base_url`, `rotate_ms: 30000`, `click_url` (affiliate: `winzir.ph/affiliates/?btag=557078_l386511`), and image lists per folder type.
- **`_includes/ads/winzir/`** — custom-image duplicates of each Google slot via a shared `_carousel.html` engine, chosen by folder type.
- **`_includes/ads/{home-banner,in-feed,vertical,rectangle}.html`** — thin dispatchers: Google markup (unchanged, gated) *or* the Winzir carousel.
- **`_layouts/default.html`** — gates the AdSense loader and adds the once-per-page rotation script.

## Slot → folder mapping
| Slot | Winzir folder |
|---|---|
| home-banner | `leaderboard` (950×250) |
| in-feed / vertical / rectangle | `rectangle` |
| (available, unplaced) | `inline-banner` |

## Notes
- Filenames with spaces (e.g. `B400x350 - taboola.png`) are URL-encoded to `%20` — verified reachable on CloudFront (HTTP 200).
- Ad images carry `ignore-lazy-image-load` so the lazy-load plugin doesn't rewrite their `src`.
- Affiliate links open in a new tab with `rel="noopener sponsored nofollow"`.
- Applies to all pages via `default.html` inheritance. `0` AdSense units render while `provider: winzir`.
- Local `images/posts/winzir-ads/**` are gitignored (assets live on CloudFront) and intentionally not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)