### PR TITLE
Add Halad Sa Pagtuo Updates nav menu and landing page

### DIFF
--- a/HaladSaPagtuoUpdates/index.html
+++ b/HaladSaPagtuoUpdates/index.html
@@ -1,0 +1,65 @@
+---
+layout: default
+title: Halad Sa Pagtuo Updates
+description: "Latest news, stories, and updates on Halad Sa Pagtuo — celebrating faith, heritage, and devotion across the Bisaya region."
+isTop: true
+---
+<main>
+    <!-- ads -->
+    <div class="container">
+        {% include ads/home-banner.html %}
+    </div>
+    <!--archive header-->
+    <div class="archive-header pt-50 pb-30" style="margin-bottom: 20px;">
+        <div class="container">
+            <div class="section-header text-left">
+                <h3 class="font-weight-900 mb-20">
+                    <span class="orange-bar"></span>
+                    #HaladSaPagtuoUpdates
+                </h3>
+                <p class="section-description mb-10 text-left">Latest news, stories, and updates on Halad Sa Pagtuo — celebrating faith, heritage, and devotion across the Bisaya region.</p>
+            </div>
+        </div>
+    </div>
+    <div class="container">
+        <div class="loop-grid mb-30">
+            <div class="row">
+                {% assign halad_posts = site.posts | where_exp: "post", "post.tags contains 'HaladSaPagtuoUpdates' or post.tags contains 'HaladSaPagtuo' or post.tags contains 'HaladSaPagtuoPH'" %}
+                {% if halad_posts.size == 0 %}
+                <div class="col-12 text-center py-50">
+                    <i class="fas fa-praying-hands" style="font-size: 48px; color: #6a1b9a;"></i>
+                    <h4 class="mt-3 mb-2">No posts yet</h4>
+                    <p class="color-grey">Coverage of Halad Sa Pagtuo will appear here as stories are published.</p>
+                </div>
+                {% else %}
+                {% for post in halad_posts %}
+
+                <div class="col-lg-4 col-md-6 mb-30">
+                    <article class="post-card border-radius-10 wow fadeInUp animated">
+                        <div class="post-thumb">
+                            <a href="{{ post.url }}">
+                                <img src="{{ post.img_medium_400x300 | default: post.img_big_1000x600 | default: 'https://via.placeholder.com/400x300' }}" alt="{{ post.title }}" class="border-radius-10">
+                            </a>
+                            <div class="post-category-badge text-white" style="background-color: #6a1b9a;">
+                                {{ post.category | default: "Halad Sa Pagtuo" }}
+                            </div>
+                        </div>
+                        <div class="post-content pt-20">
+                            <h4 class="post-title mb-15">
+                                <a href="{{ post.url }}">{{ post.title }}</a>
+                            </h4>
+                            <div class="post-meta color-muted font-small mb-15">
+                                <span class="post-by">{{ post.author }}</span>
+                                <span class="post-on has-dot">{{ post.date | date: '%b %d, %Y' }}</span>
+                            </div>
+                            <p class="post-excerpt color-grey">{{ post.excerpt | strip_html | truncatewords: 20 }}</p>
+                        </div>
+                    </article>
+                </div>
+
+                {% endfor %}
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</main>

--- a/_includes/header-orange.html
+++ b/_includes/header-orange.html
@@ -85,6 +85,11 @@
                                     <i class="fas fa-wind mr-2"></i>Super Typhoon Francisco
                                 </a>
                             </li> -->
+                            <li class="nav-item {% if page.url == '/HaladSaPagtuoUpdates/' %}active{% endif %}">
+                                <a href="/HaladSaPagtuoUpdates/" class="nav-link text-white">
+                                    <i class="fas fa-praying-hands mr-2"></i>Halad Sa Pagtuo
+                                </a>
+                            </li>
                         </ul>
 
                         <!-- Actions on Right -->
@@ -144,6 +149,11 @@
                                         <i class="fas fa-wind mr-2"></i>Super Typhoon Francisco
                                     </a>
                                 </li> -->
+                                <li class="{% if page.url == '/HaladSaPagtuoUpdates/' %}active{% endif %}">
+                                    <a href="/HaladSaPagtuoUpdates/" class="mobile-nav-link">
+                                        <i class="fas fa-praying-hands mr-2"></i>Halad Sa Pagtuo
+                                    </a>
+                                </li>
                             </ul>
                         </div>
                     </nav>


### PR DESCRIPTION
## Summary
- Adds a new **Halad Sa Pagtuo** navigation item (desktop + mobile) in `_includes/header-orange.html`, the active header include used by the `default` layout.
- Adds a new landing page at `/HaladSaPagtuoUpdates/` that auto-collects posts tagged `#HaladSaPagtuoUpdates` (also matches `HaladSaPagtuo` / `HaladSaPagtuoPH`).
- Follows the same card-grid pattern as the existing topic pages (e.g. Super Typhoon Francisco), with a faith-themed style and a friendly "No posts yet" empty state until stories are tagged.

## Notes
- `jekyll build` passes; nav link renders on regular pages, and the topic page renders at `/HaladSaPagtuoUpdates/`.
- Tag posts with `HaladSaPagtuoUpdates` to have them appear on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)